### PR TITLE
feat(env): improve host command env injection and trust

### DIFF
--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -1749,20 +1749,22 @@ async function resolveBrewPath(): Promise<string | null> {
 }
 
 async function restartMacDnsmasq(): Promise<void> {
+  const brew = await resolveBrewPath();
   if (await pathExists(MAC_DNS_RECOVERY_HELPER_PATH)) {
     const restartExit = await runMacPrivilegedCommand({
       command: [MAC_DNS_RECOVERY_HELPER_PATH, "restart-dnsmasq"],
       interactive: isInteractiveTerminal(),
     });
-    if (restartExit !== 0) {
+    if (restartExit === 0) {
+      return;
+    }
+    if (!brew) {
       throw new Error(
         `sudo ${MAC_DNS_RECOVERY_HELPER_PATH} restart-dnsmasq failed (exit ${restartExit})`
       );
     }
-    return;
   }
 
-  const brew = await resolveBrewPath();
   if (!brew) {
     throw new Error("Homebrew not found; cannot restart dnsmasq");
   }
@@ -3117,12 +3119,19 @@ async function ensureMacDnsmasqRunning(): Promise<void> {
   });
 
   const interactive = isInteractiveTerminal();
-  const exit = await runMacPrivilegedCommand({
-    command: (await pathExists(MAC_DNS_RECOVERY_HELPER_PATH))
+  const helperInstalled = await pathExists(MAC_DNS_RECOVERY_HELPER_PATH);
+  let exit = await runMacPrivilegedCommand({
+    command: helperInstalled
       ? [MAC_DNS_RECOVERY_HELPER_PATH, "restart-dnsmasq"]
       : [brew, "services", "restart", "dnsmasq"],
     interactive,
   });
+  if (helperInstalled && exit !== 0) {
+    exit = await runMacPrivilegedCommand({
+      command: [brew, "services", "restart", "dnsmasq"],
+      interactive,
+    });
+  }
   if (exit !== 0) {
     logger.warn({
       message: interactive

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -1703,10 +1703,17 @@ async function globalDown(): Promise<number> {
           interactive: isInteractiveTerminal(),
         });
       } else {
-        logger.warn({
-          message:
-            "DNS recovery helper is not installed; run `hack global authorize` before stopping dnsmasq without a password prompt.",
-        });
+        const brew = await resolveBrewPath();
+        if (brew) {
+          await runMacPrivilegedCommand({
+            command: [brew, "services", "stop", "dnsmasq"],
+            interactive: isInteractiveTerminal(),
+          });
+        } else {
+          logger.warn({
+            message: "Homebrew not found; skipping dnsmasq shutdown",
+          });
+        }
       }
     }
   }
@@ -3111,7 +3118,9 @@ async function ensureMacDnsmasqRunning(): Promise<void> {
 
   const interactive = isInteractiveTerminal();
   const exit = await runMacPrivilegedCommand({
-    command: [MAC_DNS_RECOVERY_HELPER_PATH, "restart-dnsmasq"],
+    command: (await pathExists(MAC_DNS_RECOVERY_HELPER_PATH))
+      ? [MAC_DNS_RECOVERY_HELPER_PATH, "restart-dnsmasq"]
+      : [brew, "services", "restart", "dnsmasq"],
     interactive,
   });
   if (exit !== 0) {

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -792,12 +792,7 @@ async function globalAuthorize(): Promise<number> {
     return 1;
   }
 
-  if (await pathExists(MAC_DNS_SUDOERS_PATH)) {
-    logger.info({
-      message: `${MAC_DNS_SUDOERS_PATH} already installed`,
-    });
-    return 0;
-  }
+  const sudoersRuleExists = await pathExists(MAC_DNS_SUDOERS_PATH);
 
   const brew = await findExecutableInPath("brew");
   if (!brew) {
@@ -824,6 +819,12 @@ async function globalAuthorize(): Promise<number> {
   if (!ok) {
     logger.info({ message: "Skipped DNS authorization setup" });
     return 0;
+  }
+
+  if (sudoersRuleExists) {
+    logger.info({
+      message: `Refreshing ${MAC_DNS_SUDOERS_PATH}`,
+    });
   }
 
   const tempDir = resolve(getGlobalPaths().root, "tmp");

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -939,16 +939,25 @@ async function globalAuthorize(): Promise<number> {
     return 1;
   }
 
-  const verifyAuthorizationExit = await run(
+  const verifyAuthorizationExit = await run(["sudo", "-k"], {
+    stdin: "ignore",
+  });
+  if (verifyAuthorizationExit !== 0) {
+    logger.warn({
+      message: `Unable to invalidate the sudo authentication timestamp before verification (exit ${verifyAuthorizationExit}).`,
+    });
+  }
+
+  const verifyPasswordlessExit = await run(
     ["sudo", "-n", MAC_DNS_RECOVERY_HELPER_PATH, "check"],
     {
       stdin: "ignore",
     }
   );
-  if (verifyAuthorizationExit !== 0) {
+  if (verifyPasswordlessExit !== 0) {
     logger.error({
       message: [
-        `Installed ${MAC_DNS_SUDOERS_PATH}, but passwordless DNS authorization is still not active (sudo exit ${verifyAuthorizationExit}).`,
+        `Installed ${MAC_DNS_SUDOERS_PATH}, but passwordless DNS authorization is still not active (sudo exit ${verifyPasswordlessExit}).`,
         `Check whether your main sudoers config includes ${dirname(MAC_DNS_SUDOERS_PATH)} and whether another sudoers rule is overriding Hack's entry.`,
       ].join("\n"),
     });

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -109,6 +109,8 @@ import { resolvePreferredHostDnsTarget } from "./doctor-utils.ts";
 const WHITESPACE_PATTERN = /\s+/;
 const MAC_DNS_SUDOERS_PATH = "/etc/sudoers.d/dance.hack-dns-recovery";
 const MAC_DNS_SUDOERS_TEMP_FILENAME = "dance.hack-dns-recovery.sudoers";
+const MAC_DNS_RECOVERY_HELPER_PATH = "/usr/local/libexec/hack-dns-recovery";
+const MAC_DNS_RECOVERY_HELPER_TEMP_FILENAME = "hack-dns-recovery";
 
 const globalLogsOptions = [optFollow, optNoFollow, optTail, optPretty] as const;
 const globalLogsPositionals = [{ name: "service", required: false }] as const;
@@ -830,8 +832,18 @@ async function globalAuthorize(): Promise<number> {
   const tempDir = resolve(getGlobalPaths().root, "tmp");
   await ensureDir(tempDir);
   const tempPath = resolve(tempDir, MAC_DNS_SUDOERS_TEMP_FILENAME);
+  const helperTempPath = resolve(
+    tempDir,
+    MAC_DNS_RECOVERY_HELPER_TEMP_FILENAME
+  );
+  await Bun.write(
+    helperTempPath,
+    renderMacDnsRecoveryHelper({
+      brewPath: brew,
+    })
+  );
   const sudoersText = renderMacDnsSudoers({
-    brewPath: brew,
+    helperPath: MAC_DNS_RECOVERY_HELPER_PATH,
     user,
   });
   await Bun.write(tempPath, sudoersText);
@@ -848,6 +860,46 @@ async function globalAuthorize(): Promise<number> {
   }
 
   logger.step({ message: "Installing DNS recovery sudoers rule…" });
+  const installHelperDirExit = await run(
+    [
+      "sudo",
+      "install",
+      "-d",
+      "-m",
+      "0755",
+      dirname(MAC_DNS_RECOVERY_HELPER_PATH),
+    ],
+    {
+      stdin: "inherit",
+    }
+  );
+  if (installHelperDirExit !== 0) {
+    logger.error({
+      message: `Failed to create ${dirname(MAC_DNS_RECOVERY_HELPER_PATH)} (exit ${installHelperDirExit})`,
+    });
+    return 1;
+  }
+
+  const installHelperExit = await run(
+    [
+      "sudo",
+      "install",
+      "-m",
+      "0755",
+      helperTempPath,
+      MAC_DNS_RECOVERY_HELPER_PATH,
+    ],
+    {
+      stdin: "inherit",
+    }
+  );
+  if (installHelperExit !== 0) {
+    logger.error({
+      message: `Failed to install ${MAC_DNS_RECOVERY_HELPER_PATH} (exit ${installHelperExit})`,
+    });
+    return 1;
+  }
+
   const installDirExit = await run(
     ["sudo", "install", "-d", "-m", "0755", "/etc/sudoers.d"],
     {
@@ -887,16 +939,31 @@ async function globalAuthorize(): Promise<number> {
     return 1;
   }
 
+  const verifyAuthorizationExit = await run(
+    ["sudo", "-n", MAC_DNS_RECOVERY_HELPER_PATH, "check"],
+    {
+      stdin: "ignore",
+    }
+  );
+  if (verifyAuthorizationExit !== 0) {
+    logger.error({
+      message: [
+        `Installed ${MAC_DNS_SUDOERS_PATH}, but passwordless DNS authorization is still not active (sudo exit ${verifyAuthorizationExit}).`,
+        `Check whether your main sudoers config includes ${dirname(MAC_DNS_SUDOERS_PATH)} and whether another sudoers rule is overriding Hack's entry.`,
+      ].join("\n"),
+    });
+    return 1;
+  }
+
   logger.success({
     message: `Installed ${MAC_DNS_SUDOERS_PATH}`,
   });
   note(
     [
       "Authorized commands:",
-      `- sudo ${brew} services restart dnsmasq`,
-      `- sudo ${brew} services stop dnsmasq`,
-      "- sudo /usr/bin/dscacheutil -flushcache",
-      "- sudo /usr/bin/killall -HUP mDNSResponder",
+      `- sudo ${MAC_DNS_RECOVERY_HELPER_PATH} restart-dnsmasq`,
+      `- sudo ${MAC_DNS_RECOVERY_HELPER_PATH} stop-dnsmasq`,
+      `- sudo ${MAC_DNS_RECOVERY_HELPER_PATH} flush-cache`,
     ].join("\n"),
     "DNS authorization"
   );
@@ -904,13 +971,44 @@ async function globalAuthorize(): Promise<number> {
 }
 
 function renderMacDnsSudoers(opts: {
-  readonly brewPath: string;
+  readonly helperPath: string;
   readonly user: string;
 }): string {
   return [
     "# Managed by hack for local DNS recovery.",
     "# Allows Hack to repair dnsmasq and macOS DNS cache without prompting.",
-    `${opts.user} ALL = (root) NOPASSWD: ${opts.brewPath} services restart dnsmasq, ${opts.brewPath} services stop dnsmasq, /usr/bin/dscacheutil -flushcache, /usr/bin/killall -HUP mDNSResponder`,
+    `${opts.user} ALL = (root) NOPASSWD: ${opts.helperPath} check, ${opts.helperPath} restart-dnsmasq, ${opts.helperPath} stop-dnsmasq, ${opts.helperPath} flush-cache`,
+    "",
+  ].join("\n");
+}
+
+function renderMacDnsRecoveryHelper(opts: {
+  readonly brewPath: string;
+}): string {
+  return [
+    "#!/bin/sh",
+    "set -eu",
+    `brew_path=${JSON.stringify(opts.brewPath)}`,
+    `command="\${1:-}"`,
+    'case "$command" in',
+    "  check)",
+    "    exit 0",
+    "    ;;",
+    "  restart-dnsmasq)",
+    '    exec "$brew_path" services restart dnsmasq',
+    "    ;;",
+    "  stop-dnsmasq)",
+    '    exec "$brew_path" services stop dnsmasq',
+    "    ;;",
+    "  flush-cache)",
+    "    /usr/bin/dscacheutil -flushcache",
+    "    exec /usr/bin/killall -HUP mDNSResponder",
+    "    ;;",
+    "  *)",
+    '    echo "usage: hack-dns-recovery {check|restart-dnsmasq|stop-dnsmasq|flush-cache}" >&2',
+    "    exit 64",
+    "    ;;",
+    "esac",
     "",
   ].join("\n");
 }
@@ -1590,15 +1688,15 @@ async function globalDown(): Promise<number> {
     }
     if (ok) {
       logger.step({ message: "Stopping dnsmasq (requires sudo)…" });
-      const brew = await resolveBrewPath();
-      if (brew) {
+      if (await pathExists(MAC_DNS_RECOVERY_HELPER_PATH)) {
         await runMacPrivilegedCommand({
-          command: [brew, "services", "stop", "dnsmasq"],
+          command: [MAC_DNS_RECOVERY_HELPER_PATH, "stop-dnsmasq"],
           interactive: isInteractiveTerminal(),
         });
       } else {
         logger.warn({
-          message: "Homebrew not found; skipping dnsmasq shutdown",
+          message:
+            "DNS recovery helper is not installed; run `hack global authorize` before stopping dnsmasq without a password prompt.",
         });
       }
     }
@@ -1635,6 +1733,19 @@ async function resolveBrewPath(): Promise<string | null> {
 }
 
 async function restartMacDnsmasq(): Promise<void> {
+  if (await pathExists(MAC_DNS_RECOVERY_HELPER_PATH)) {
+    const restartExit = await runMacPrivilegedCommand({
+      command: [MAC_DNS_RECOVERY_HELPER_PATH, "restart-dnsmasq"],
+      interactive: isInteractiveTerminal(),
+    });
+    if (restartExit !== 0) {
+      throw new Error(
+        `sudo ${MAC_DNS_RECOVERY_HELPER_PATH} restart-dnsmasq failed (exit ${restartExit})`
+      );
+    }
+    return;
+  }
+
   const brew = await resolveBrewPath();
   if (!brew) {
     throw new Error("Homebrew not found; cannot restart dnsmasq");
@@ -1652,6 +1763,19 @@ async function restartMacDnsmasq(): Promise<void> {
 }
 
 async function flushMacDnsCachePrivileged(): Promise<void> {
+  if (await pathExists(MAC_DNS_RECOVERY_HELPER_PATH)) {
+    const flushExit = await runMacPrivilegedCommand({
+      command: [MAC_DNS_RECOVERY_HELPER_PATH, "flush-cache"],
+      interactive: isInteractiveTerminal(),
+    });
+    if (flushExit !== 0) {
+      throw new Error(
+        `sudo ${MAC_DNS_RECOVERY_HELPER_PATH} flush-cache failed (exit ${flushExit})`
+      );
+    }
+    return;
+  }
+
   const flushExit = await runMacPrivilegedCommand({
     command: ["/usr/bin/dscacheutil", "-flushcache"],
     interactive: isInteractiveTerminal(),
@@ -2978,7 +3102,7 @@ async function ensureMacDnsmasqRunning(): Promise<void> {
 
   const interactive = isInteractiveTerminal();
   const exit = await runMacPrivilegedCommand({
-    command: [brew, "services", "restart", "dnsmasq"],
+    command: [MAC_DNS_RECOVERY_HELPER_PATH, "restart-dnsmasq"],
     interactive,
   });
   if (exit !== 0) {

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -1698,22 +1698,26 @@ async function globalDown(): Promise<number> {
     if (ok) {
       logger.step({ message: "Stopping dnsmasq (requires sudo)…" });
       if (await pathExists(MAC_DNS_RECOVERY_HELPER_PATH)) {
-        await runMacPrivilegedCommand({
+        const helperExit = await runMacPrivilegedCommand({
           command: [MAC_DNS_RECOVERY_HELPER_PATH, "stop-dnsmasq"],
           interactive: isInteractiveTerminal(),
         });
-      } else {
-        const brew = await resolveBrewPath();
-        if (brew) {
-          await runMacPrivilegedCommand({
-            command: [brew, "services", "stop", "dnsmasq"],
-            interactive: isInteractiveTerminal(),
-          });
-        } else {
-          logger.warn({
-            message: "Homebrew not found; skipping dnsmasq shutdown",
-          });
+        if (helperExit === 0) {
+          logger.success({ message: "Global infra is down" });
+          return 0;
         }
+      }
+
+      const brew = await resolveBrewPath();
+      if (brew) {
+        await runMacPrivilegedCommand({
+          command: [brew, "services", "stop", "dnsmasq"],
+          interactive: isInteractiveTerminal(),
+        });
+      } else {
+        logger.warn({
+          message: "Homebrew not found; skipping dnsmasq shutdown",
+        });
       }
     }
   }

--- a/tests/global-command.macos.test.ts
+++ b/tests/global-command.macos.test.ts
@@ -321,6 +321,7 @@ test("global authorize installs passwordless dns recovery sudoers rule", async (
         "-cf",
         "/etc/sudoers.d/dance.hack-dns-recovery",
       ],
+      ["sudo", "-k"],
       ["sudo", "-n", "/usr/local/libexec/hack-dns-recovery", "check"],
     ])
   );
@@ -364,6 +365,7 @@ test("global authorize refreshes an existing dns recovery sudoers rule", async (
         "-cf",
         "/etc/sudoers.d/dance.hack-dns-recovery",
       ],
+      ["sudo", "-k"],
       ["sudo", "-n", "/usr/local/libexec/hack-dns-recovery", "check"],
     ])
   );
@@ -387,6 +389,28 @@ test("global authorize uses the OS account lookup instead of USER env", async ()
   expect(sudoersText).toContain("real-login-user ALL = (root) NOPASSWD:");
   expect(sudoersText).not.toContain("spoofed-user ALL = (root) NOPASSWD:");
   expect(sudoersText).toContain("/usr/local/libexec/hack-dns-recovery check");
+});
+
+test("global authorize fails when passwordless sudo is still inactive after install", async () => {
+  runResponder = (cmd) => {
+    if (
+      cmd.join(" ") === "sudo -n /usr/local/libexec/hack-dns-recovery check"
+    ) {
+      return 1;
+    }
+    return 0;
+  };
+
+  const { runCli } = await import("../src/cli/run.ts");
+  const code = await runCli(["global", "authorize"]);
+
+  expect(code).toBe(1);
+  expect(runCalls).toEqual(
+    expect.arrayContaining([
+      ["sudo", "-k"],
+      ["sudo", "-n", "/usr/local/libexec/hack-dns-recovery", "check"],
+    ])
+  );
 });
 
 test("global up tries passwordless sudo before prompting for dnsmasq recovery", async () => {

--- a/tests/global-command.macos.test.ts
+++ b/tests/global-command.macos.test.ts
@@ -473,6 +473,51 @@ test("global up uses the dns recovery helper when it is installed", async () => 
   ]);
 });
 
+test("global up falls back to brew when the helper restart fails", async () => {
+  pathExistsOverrides.set("/usr/local/libexec/hack-dns-recovery", true);
+  const caddyCompose = join(
+    tempDir!,
+    GLOBAL_HACK_DIR_NAME,
+    GLOBAL_CADDY_DIR_NAME,
+    GLOBAL_CADDY_COMPOSE_FILENAME
+  );
+  const loggingCompose = join(
+    tempDir!,
+    GLOBAL_HACK_DIR_NAME,
+    GLOBAL_LOGGING_DIR_NAME,
+    GLOBAL_LOGGING_COMPOSE_FILENAME
+  );
+  await writeComposeFile(caddyCompose);
+  await writeComposeFile(loggingCompose);
+  runResponder = (cmd) => {
+    if (
+      cmd.join(" ") ===
+      "sudo -n /usr/local/libexec/hack-dns-recovery restart-dnsmasq"
+    ) {
+      return 1;
+    }
+    return 0;
+  };
+
+  const { runCli } = await import("../src/cli/run.ts");
+  const code = await runCli(["global", "up"]);
+
+  expect(code).toBe(0);
+  expect(runCalls).toEqual(
+    expect.arrayContaining([
+      ["sudo", "-n", "/usr/local/libexec/hack-dns-recovery", "restart-dnsmasq"],
+      [
+        "sudo",
+        "-n",
+        "/opt/homebrew/bin/brew",
+        "services",
+        "restart",
+        "dnsmasq",
+      ],
+    ])
+  );
+});
+
 test("global up falls back to interactive sudo when stdin is tty but stdout is redirected", async () => {
   const caddyCompose = join(
     tempDir!,

--- a/tests/global-command.macos.test.ts
+++ b/tests/global-command.macos.test.ts
@@ -316,6 +316,39 @@ test("global authorize installs passwordless dns recovery sudoers rule", async (
   );
 });
 
+test("global authorize refreshes an existing dns recovery sudoers rule", async () => {
+  pathExistsOverrides.set("/etc/sudoers.d/dance.hack-dns-recovery", true);
+
+  const { runCli } = await import("../src/cli/run.ts");
+  const code = await runCli(["global", "authorize"]);
+
+  expect(code).toBe(0);
+  expect(runCalls).toEqual(
+    expect.arrayContaining([
+      [
+        "/usr/bin/mock-bin",
+        "-cf",
+        expect.stringContaining("dance.hack-dns-recovery.sudoers"),
+      ],
+      ["sudo", "install", "-d", "-m", "0755", "/etc/sudoers.d"],
+      [
+        "sudo",
+        "install",
+        "-m",
+        "0440",
+        expect.stringContaining("dance.hack-dns-recovery.sudoers"),
+        "/etc/sudoers.d/dance.hack-dns-recovery",
+      ],
+      [
+        "sudo",
+        "/usr/bin/mock-bin",
+        "-cf",
+        "/etc/sudoers.d/dance.hack-dns-recovery",
+      ],
+    ])
+  );
+});
+
 test("global authorize uses the OS account lookup instead of USER env", async () => {
   idUser = "real-login-user";
   process.env.USER = "spoofed-user";

--- a/tests/global-command.macos.test.ts
+++ b/tests/global-command.macos.test.ts
@@ -600,6 +600,31 @@ test("global down falls back to brew stop when the dns recovery helper is missin
   );
 });
 
+test("global down falls back to brew stop when the helper stop fails", async () => {
+  pathExistsOverrides.set("/usr/local/libexec/hack-dns-recovery", true);
+  runResponder = (cmd) => {
+    if (
+      cmd.join(" ") ===
+        "sudo -n /usr/local/libexec/hack-dns-recovery stop-dnsmasq" ||
+      cmd.join(" ") === "sudo /usr/local/libexec/hack-dns-recovery stop-dnsmasq"
+    ) {
+      return 1;
+    }
+    return 0;
+  };
+
+  const { runCli } = await import("../src/cli/run.ts");
+  const code = await runCli(["global", "down"]);
+
+  expect(code).toBe(0);
+  expect(runCalls).toEqual(
+    expect.arrayContaining([
+      ["sudo", "-n", "/usr/local/libexec/hack-dns-recovery", "stop-dnsmasq"],
+      ["sudo", "-n", "/opt/homebrew/bin/brew", "services", "stop", "dnsmasq"],
+    ])
+  );
+});
+
 test("global trust prepares host runtime trust env for future shells", async () => {
   const caddyCompose = join(
     tempDir!,

--- a/tests/global-command.macos.test.ts
+++ b/tests/global-command.macos.test.ts
@@ -256,6 +256,15 @@ test("global install keeps container ip host dns when bridge ip is reachable", a
   expect(runCalls).toEqual(
     expect.arrayContaining([
       ["sudo", "install", "-d", "-m", "0755", "/etc/sudoers.d"],
+      ["sudo", "install", "-d", "-m", "0755", "/usr/local/libexec"],
+      [
+        "sudo",
+        "install",
+        "-m",
+        "0755",
+        expect.stringContaining("hack-dns-recovery"),
+        "/usr/local/libexec/hack-dns-recovery",
+      ],
       [
         "sudo",
         "install",
@@ -312,6 +321,7 @@ test("global authorize installs passwordless dns recovery sudoers rule", async (
         "-cf",
         "/etc/sudoers.d/dance.hack-dns-recovery",
       ],
+      ["sudo", "-n", "/usr/local/libexec/hack-dns-recovery", "check"],
     ])
   );
 });
@@ -331,6 +341,15 @@ test("global authorize refreshes an existing dns recovery sudoers rule", async (
         expect.stringContaining("dance.hack-dns-recovery.sudoers"),
       ],
       ["sudo", "install", "-d", "-m", "0755", "/etc/sudoers.d"],
+      ["sudo", "install", "-d", "-m", "0755", "/usr/local/libexec"],
+      [
+        "sudo",
+        "install",
+        "-m",
+        "0755",
+        expect.stringContaining("hack-dns-recovery"),
+        "/usr/local/libexec/hack-dns-recovery",
+      ],
       [
         "sudo",
         "install",
@@ -345,6 +364,7 @@ test("global authorize refreshes an existing dns recovery sudoers rule", async (
         "-cf",
         "/etc/sudoers.d/dance.hack-dns-recovery",
       ],
+      ["sudo", "-n", "/usr/local/libexec/hack-dns-recovery", "check"],
     ])
   );
 });
@@ -366,6 +386,7 @@ test("global authorize uses the OS account lookup instead of USER env", async ()
   const sudoersText = await Bun.file(sudoersPath).text();
   expect(sudoersText).toContain("real-login-user ALL = (root) NOPASSWD:");
   expect(sudoersText).not.toContain("spoofed-user ALL = (root) NOPASSWD:");
+  expect(sudoersText).toContain("/usr/local/libexec/hack-dns-recovery check");
 });
 
 test("global up tries passwordless sudo before prompting for dnsmasq recovery", async () => {
@@ -391,10 +412,8 @@ test("global up tries passwordless sudo before prompting for dnsmasq recovery", 
   expect(runCalls[0]).toEqual([
     "sudo",
     "-n",
-    "/opt/homebrew/bin/brew",
-    "services",
-    "restart",
-    "dnsmasq",
+    "/usr/local/libexec/hack-dns-recovery",
+    "restart-dnsmasq",
   ]);
 });
 
@@ -433,7 +452,7 @@ test("global up falls back to interactive sudo when stdin is tty but stdout is r
   runResponder = (cmd) => {
     if (
       cmd.join(" ") ===
-      "sudo -n /opt/homebrew/bin/brew services restart dnsmasq"
+      "sudo -n /usr/local/libexec/hack-dns-recovery restart-dnsmasq"
     ) {
       return 1;
     }
@@ -450,12 +469,10 @@ test("global up falls back to interactive sudo when stdin is tty but stdout is r
         [
           "sudo",
           "-n",
-          "/opt/homebrew/bin/brew",
-          "services",
-          "restart",
-          "dnsmasq",
+          "/usr/local/libexec/hack-dns-recovery",
+          "restart-dnsmasq",
         ],
-        ["sudo", "/opt/homebrew/bin/brew", "services", "restart", "dnsmasq"],
+        ["sudo", "/usr/local/libexec/hack-dns-recovery", "restart-dnsmasq"],
       ])
     );
   } finally {

--- a/tests/global-command.macos.test.ts
+++ b/tests/global-command.macos.test.ts
@@ -184,6 +184,7 @@ beforeEach(async () => {
   execMockResponder = null;
   pathExistsOverrides = new Map([
     ["/etc/sudoers.d/dance.hack-dns-recovery", false],
+    ["/usr/local/libexec/hack-dns-recovery", false],
   ]);
   reachabilityByHost = {};
   idUser = "mock-user";
@@ -436,6 +437,37 @@ test("global up tries passwordless sudo before prompting for dnsmasq recovery", 
   expect(runCalls[0]).toEqual([
     "sudo",
     "-n",
+    "/opt/homebrew/bin/brew",
+    "services",
+    "restart",
+    "dnsmasq",
+  ]);
+});
+
+test("global up uses the dns recovery helper when it is installed", async () => {
+  pathExistsOverrides.set("/usr/local/libexec/hack-dns-recovery", true);
+  const caddyCompose = join(
+    tempDir!,
+    GLOBAL_HACK_DIR_NAME,
+    GLOBAL_CADDY_DIR_NAME,
+    GLOBAL_CADDY_COMPOSE_FILENAME
+  );
+  const loggingCompose = join(
+    tempDir!,
+    GLOBAL_HACK_DIR_NAME,
+    GLOBAL_LOGGING_DIR_NAME,
+    GLOBAL_LOGGING_COMPOSE_FILENAME
+  );
+  await writeComposeFile(caddyCompose);
+  await writeComposeFile(loggingCompose);
+
+  const { runCli } = await import("../src/cli/run.ts");
+  const code = await runCli(["global", "up"]);
+
+  expect(code).toBe(0);
+  expect(runCalls[0]).toEqual([
+    "sudo",
+    "-n",
     "/usr/local/libexec/hack-dns-recovery",
     "restart-dnsmasq",
   ]);
@@ -476,7 +508,7 @@ test("global up falls back to interactive sudo when stdin is tty but stdout is r
   runResponder = (cmd) => {
     if (
       cmd.join(" ") ===
-      "sudo -n /usr/local/libexec/hack-dns-recovery restart-dnsmasq"
+      "sudo -n /opt/homebrew/bin/brew services restart dnsmasq"
     ) {
       return 1;
     }
@@ -493,10 +525,12 @@ test("global up falls back to interactive sudo when stdin is tty but stdout is r
         [
           "sudo",
           "-n",
-          "/usr/local/libexec/hack-dns-recovery",
-          "restart-dnsmasq",
+          "/opt/homebrew/bin/brew",
+          "services",
+          "restart",
+          "dnsmasq",
         ],
-        ["sudo", "/usr/local/libexec/hack-dns-recovery", "restart-dnsmasq"],
+        ["sudo", "/opt/homebrew/bin/brew", "services", "restart", "dnsmasq"],
       ])
     );
   } finally {
@@ -507,6 +541,18 @@ test("global up falls back to interactive sudo when stdin is tty but stdout is r
       Object.defineProperty(process.stdout, "isTTY", stdoutDescriptor);
     }
   }
+});
+
+test("global down falls back to brew stop when the dns recovery helper is missing", async () => {
+  const { runCli } = await import("../src/cli/run.ts");
+  const code = await runCli(["global", "down"]);
+
+  expect(code).toBe(0);
+  expect(runCalls).toEqual(
+    expect.arrayContaining([
+      ["sudo", "-n", "/opt/homebrew/bin/brew", "services", "stop", "dnsmasq"],
+    ])
+  );
 });
 
 test("global trust prepares host runtime trust env for future shells", async () => {


### PR DESCRIPTION
## Summary
- wire Hack local CA trust into host-side env and global trust/install flows
- add safer host command ergonomics and coverage for env/host/session/project paths
- harden macOS dns recovery authorization with a root-owned helper and real passwordless verification

## Verification
- bun test tests/env-exec-command.test.ts tests/session-env-command.test.ts tests/project-lifecycle-processes.test.ts tests/global-command.macos.test.ts tests/doctor-command.test.ts tests/doctor-host-trust.test.ts
- bunx tsc -p packages/cli/tsconfig.json --noEmit
- bun x ultracite check src/lib/local-ca.ts src/lib/doctor-host-tls.ts src/commands/env.ts src/commands/session.ts src/commands/project.ts src/commands/global.ts src/commands/doctor.ts tests/env-exec-command.test.ts tests/session-env-command.test.ts tests/project-lifecycle-processes.test.ts tests/global-command.macos.test.ts tests/doctor-command.test.ts tests/doctor-host-trust.test.ts docs/env.md docs/cli.md docs/integrations.md docs/guides/codex-managed-environments.md