### PR TITLE
fix(global): validate dns helper path before install

### DIFF
--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -862,6 +862,20 @@ async function globalAuthorize(): Promise<number> {
   }
 
   logger.step({ message: "Installing DNS recovery sudoers rule…" });
+  const parentPathsSecure = await verifyMacRootControlledPaths([
+    dirname(dirname(MAC_DNS_RECOVERY_HELPER_PATH)),
+    dirname(MAC_DNS_RECOVERY_HELPER_PATH),
+  ]);
+  if (!parentPathsSecure) {
+    logger.error({
+      message: [
+        `${MAC_DNS_RECOVERY_HELPER_PATH} is not under a root-controlled path.`,
+        "Refusing to authorize passwordless sudo for an insecure helper location.",
+      ].join(" "),
+    });
+    return 1;
+  }
+
   const installHelperDirExit = await run(
     [
       "sudo",
@@ -910,7 +924,9 @@ async function globalAuthorize(): Promise<number> {
     return 1;
   }
 
-  const helperSecurityOk = await verifyMacDnsRecoveryHelperSecurity();
+  const helperSecurityOk = await verifyMacRootControlledPaths([
+    MAC_DNS_RECOVERY_HELPER_PATH,
+  ]);
   if (!helperSecurityOk) {
     logger.error({
       message: [
@@ -1069,14 +1085,10 @@ function toPosixShellSingleQuotedLiteral(value: string): string {
   return `'${value.replaceAll("'", String.raw`'\''`)}'`;
 }
 
-async function verifyMacDnsRecoveryHelperSecurity(): Promise<boolean> {
-  const securePaths = [
-    dirname(dirname(MAC_DNS_RECOVERY_HELPER_PATH)),
-    dirname(MAC_DNS_RECOVERY_HELPER_PATH),
-    MAC_DNS_RECOVERY_HELPER_PATH,
-  ];
-
-  for (const path of securePaths) {
+async function verifyMacRootControlledPaths(
+  paths: readonly string[]
+): Promise<boolean> {
+  for (const path of paths) {
     const metadata = await readMacOwnershipAndMode(path);
     if (metadata === null) {
       logger.error({

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -862,10 +862,15 @@ async function globalAuthorize(): Promise<number> {
   }
 
   logger.step({ message: "Installing DNS recovery sudoers rule…" });
-  const parentPathsSecure = await verifyMacRootControlledPaths([
-    dirname(dirname(MAC_DNS_RECOVERY_HELPER_PATH)),
-    dirname(MAC_DNS_RECOVERY_HELPER_PATH),
-  ]);
+  const parentPathsSecure = await verifyMacRootControlledPaths(
+    [
+      dirname(dirname(MAC_DNS_RECOVERY_HELPER_PATH)),
+      dirname(MAC_DNS_RECOVERY_HELPER_PATH),
+    ],
+    {
+      allowMissingPaths: [dirname(MAC_DNS_RECOVERY_HELPER_PATH)],
+    }
+  );
   if (!parentPathsSecure) {
     logger.error({
       message: [
@@ -925,6 +930,7 @@ async function globalAuthorize(): Promise<number> {
   }
 
   const helperSecurityOk = await verifyMacRootControlledPaths([
+    dirname(MAC_DNS_RECOVERY_HELPER_PATH),
     MAC_DNS_RECOVERY_HELPER_PATH,
   ]);
   if (!helperSecurityOk) {
@@ -1086,11 +1092,18 @@ function toPosixShellSingleQuotedLiteral(value: string): string {
 }
 
 async function verifyMacRootControlledPaths(
-  paths: readonly string[]
+  paths: readonly string[],
+  options?: {
+    readonly allowMissingPaths?: readonly string[];
+  }
 ): Promise<boolean> {
+  const allowMissingPaths = new Set(options?.allowMissingPaths ?? []);
   for (const path of paths) {
     const metadata = await readMacOwnershipAndMode(path);
     if (metadata === null) {
+      if (allowMissingPaths.has(path)) {
+        continue;
+      }
       logger.error({
         message: `Unable to inspect ownership for ${path}.`,
       });

--- a/tests/global-command.macos.test.ts
+++ b/tests/global-command.macos.test.ts
@@ -576,6 +576,62 @@ test("global authorize refuses insecure helper path ownership", async () => {
   ]);
 });
 
+test("global authorize creates missing libexec before post-install verification", async () => {
+  statMetadataByPath.delete("/usr/local/libexec");
+  statMetadataByPath.delete("/usr/local/libexec/hack-dns-recovery");
+  runResponder = (cmd) => {
+    if (
+      cmd.join(" ") ===
+      "sudo install -d -o root -g wheel -m 0755 /usr/local/libexec"
+    ) {
+      statMetadataByPath.set("/usr/local/libexec", "0:0:755");
+      return 0;
+    }
+    if (
+      cmd.join(" ") ===
+      `sudo install -o root -g wheel -m 0755 ${resolve(
+        tempDir!,
+        GLOBAL_HACK_DIR_NAME,
+        "tmp",
+        "hack-dns-recovery"
+      )} /usr/local/libexec/hack-dns-recovery`
+    ) {
+      statMetadataByPath.set("/usr/local/libexec/hack-dns-recovery", "0:0:755");
+      return 0;
+    }
+    return 0;
+  };
+
+  const { runCli } = await import("../src/cli/run.ts");
+  const code = await runCli(["global", "authorize"]);
+
+  expect(code).toBe(0);
+  expect(runCalls).toContainEqual([
+    "sudo",
+    "install",
+    "-d",
+    "-o",
+    "root",
+    "-g",
+    "wheel",
+    "-m",
+    "0755",
+    "/usr/local/libexec",
+  ]);
+  expect(execCalls).toContainEqual([
+    "/usr/bin/stat",
+    "-f",
+    "%u:%g:%Lp",
+    "/usr/local/libexec",
+  ]);
+  expect(execCalls).toContainEqual([
+    "/usr/bin/stat",
+    "-f",
+    "%u:%g:%Lp",
+    "/usr/local/libexec/hack-dns-recovery",
+  ]);
+});
+
 test("global authorize fails when passwordless sudo is still inactive after install", async () => {
   runResponder = (cmd) => {
     if (

--- a/tests/global-command.macos.test.ts
+++ b/tests/global-command.macos.test.ts
@@ -550,22 +550,30 @@ test("global authorize refuses insecure helper path ownership", async () => {
   const code = await runCli(["global", "authorize"]);
 
   expect(code).toBe(1);
-  expect(runCalls).not.toEqual(
-    expect.arrayContaining([
-      [
-        "sudo",
-        "install",
-        "-o",
-        "root",
-        "-g",
-        "wheel",
-        "-m",
-        "0440",
-        expect.stringContaining("dance.hack-dns-recovery.sudoers"),
-        "/etc/sudoers.d/dance.hack-dns-recovery",
-      ],
-    ])
-  );
+  expect(runCalls).not.toContainEqual([
+    "sudo",
+    "install",
+    "-o",
+    "root",
+    "-g",
+    "wheel",
+    "-m",
+    "0755",
+    expect.stringContaining("hack-dns-recovery"),
+    "/usr/local/libexec/hack-dns-recovery",
+  ]);
+  expect(runCalls).not.toContainEqual([
+    "sudo",
+    "install",
+    "-o",
+    "root",
+    "-g",
+    "wheel",
+    "-m",
+    "0440",
+    expect.stringContaining("dance.hack-dns-recovery.sudoers"),
+    "/etc/sudoers.d/dance.hack-dns-recovery",
+  ]);
 });
 
 test("global authorize fails when passwordless sudo is still inactive after install", async () => {


### PR DESCRIPTION
## Summary
- validate `/usr/local` and `/usr/local/libexec` security before any privileged helper write
- keep the post-install helper-file ownership check before writing sudoers
- add regression coverage so insecure parent paths abort before helper installation

## Verification
- bun test tests/global-command.macos.test.ts
- bunx tsc -p packages/cli/tsconfig.json --noEmit
- bun x ultracite check src/commands/global.ts tests/global-command.macos.test.ts
