### PR TITLE
fix(ci): restore Intel macOS build in the release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,9 @@ jobs:
           - os: blacksmith-6vcpu-macos-15
             upload_install: false
             skip_tests: true
+          - os: macos-15-intel
+            upload_install: false
+            skip_tests: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The Blacksmith migration (#52) replaced the release matrix's Intel runner with arm64-only macOS runners. First release since (v3.1.0) produced no `darwin-x86_64` tarball, so `update-homebrew-tap` failed rendering the formula. Adds `macos-15-intel` to restore the Intel build. After merge: re-dispatch the Release workflow with tag `v3.1.0` to backfill the asset and re-render the tap (uploads are `--clobber`, release creation is idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)