### PR TITLE
fix(tls): check isMac before isLinux in globalTrust

### DIFF
--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -2720,20 +2720,19 @@ async function globalTrust(): Promise<number> {
     return 1;
   }
 
-  if (isLinux()) {
-    await configureLinuxHostTlsTrust({ certPath });
+  if (isMac()) {
+    const trustReady = await ensureMacTrustCaddyLocalCa({
+      certPath,
+    });
+    if (trustReady) {
+      await configureMacHostTlsTrust({
+        certPath,
+      });
+    }
     return 0;
   }
 
-  const trustReady = await ensureMacTrustCaddyLocalCa({
-    certPath,
-  });
-  if (trustReady) {
-    await configureMacHostTlsTrust({
-      certPath,
-    });
-  }
-
+  await configureLinuxHostTlsTrust({ certPath });
   return 0;
 }
 

--- a/tests/global-command.macos.test.ts
+++ b/tests/global-command.macos.test.ts
@@ -204,6 +204,7 @@ const osMock = await registerScopedModuleMock({
   specifier: "../src/lib/os.ts",
   overrides: {
     isMac: () => true,
+    isLinux: () => false,
     openUrl: async () => 0,
   },
 });


### PR DESCRIPTION
release-prepare failed on main: tests/global-command.macos.test.ts mocks isMac()=true but not isLinux(), and the new Linux branch in globalTrust ran first on the Linux runner — building a real bundle from /etc/ssl/certs instead of the mocked keychain export. Mac branch now checks first (mutually exclusive on real platforms; mock-safe in tests), and the macOS suite pins isLinux()=false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)