### PR TITLE
fix(release): install Homebrew executable path

### DIFF
--- a/scripts/update-homebrew-tap.ts
+++ b/scripts/update-homebrew-tap.ts
@@ -25,7 +25,7 @@ interface GithubReleaseView {
   readonly assets?: unknown;
 }
 
-interface ReleaseAssetInfo {
+export interface ReleaseAssetInfo {
   readonly name: string;
   readonly sha256: string;
 }
@@ -56,12 +56,14 @@ const HELP_TEXT = [
   "  --repo <owner/name>   GitHub repo to query (default: hack-dance/hack)",
 ].join("\n");
 
-const parsed = parseArgs({ argv: Bun.argv.slice(2) });
-if (parsed.ok) {
-  process.exitCode = await main({ args: parsed.args });
-} else {
-  process.stderr.write(`${parsed.message}\n`);
-  process.exitCode = 1;
+if (import.meta.main) {
+  const parsed = parseArgs({ argv: Bun.argv.slice(2) });
+  if (parsed.ok) {
+    process.exitCode = await main({ args: parsed.args });
+  } else {
+    process.stderr.write(`${parsed.message}\n`);
+    process.exitCode = 1;
+  }
 }
 
 async function main({ args }: { readonly args: Args }): Promise<number> {
@@ -246,7 +248,7 @@ function parseAssets({
   return out;
 }
 
-function renderFormula({
+export function renderFormula({
   repo,
   tag,
   version,
@@ -287,7 +289,7 @@ function renderFormula({
     '    libexec.install "hack"',
     '    (libexec/"assets").install Dir["assets/*"] if (buildpath/"assets").directory?',
     '    (libexec/"assets/binaries").install Dir["binaries/*"] if (buildpath/"binaries").directory?',
-    '    bin.write_env_script libexec/"hack", HACK_ASSETS_DIR: libexec/"assets"',
+    '    (bin/"hack").write_env_script libexec/"hack", HACK_ASSETS_DIR: libexec/"assets"',
     "  end",
     "",
     "  test do",

--- a/tests/update-homebrew-tap.test.ts
+++ b/tests/update-homebrew-tap.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+
+import { renderFormula } from "../scripts/update-homebrew-tap.ts";
+
+test("renderFormula installs the wrapper at bin/hack", () => {
+  const formula = renderFormula({
+    repo: "hack-dance/hack",
+    tag: "v3.3.3",
+    version: "3.3.3",
+    darwinArm64: {
+      name: "hack-3.3.3-darwin-arm64.tar.gz",
+      sha256: "arm64-sha",
+    },
+    darwinX64: {
+      name: "hack-3.3.3-darwin-x86_64.tar.gz",
+      sha256: "x64-sha",
+    },
+    linuxX64: {
+      name: "hack-3.3.3-linux-x86_64.tar.gz",
+      sha256: "linux-sha",
+    },
+  });
+
+  expect(formula).toContain(
+    '(bin/"hack").write_env_script libexec/"hack", HACK_ASSETS_DIR: libexec/"assets"'
+  );
+  expect(formula).not.toContain(
+    'bin.write_env_script libexec/"hack", HACK_ASSETS_DIR: libexec/"assets"'
+  );
+  expect(formula).toContain(
+    'assert_match "hack", shell_output("#{bin}/hack --help")'
+  );
+});


### PR DESCRIPTION
## Summary

- write the Homebrew launcher to `bin/hack` instead of replacing the formula prefix's `bin` directory with a file
- make the formula renderer import-safe and directly test its generated install contract

## Production evidence

The canonical `v3.3.3` formula downloaded and installed successfully, but produced:

```text
/opt/homebrew/Cellar/hack/3.3.3/bin: Bourne-Again shell script text executable
```

Because `bin` itself was a file, Homebrew linked no `/opt/homebrew/bin/hack`, and the formula's own `#{bin}/hack --help` test path could not exist. The generator emitted `bin.write_env_script`; Homebrew requires `(bin/"hack").write_env_script`.

## Verification

- `bun test tests/update-homebrew-tap.test.ts` — 1 passed
- `bunx ultracite check scripts/update-homebrew-tap.ts tests/update-homebrew-tap.test.ts` — passed
- `bun run --cwd packages/cli typecheck` — passed
- real renderer invocation against release `v3.3.3` produced `Formula/hack.rb` with `(bin/"hack").write_env_script` and the existing `#{bin}/hack --help` formula test

## Compatibility and release signal

- release tarball layout and CLI behavior are unchanged
- only the generated Homebrew installation path changes
- this is a production packaging fix and should trigger the next patch release so the release workflow republishes the corrected formula
